### PR TITLE
Add .gitignore file for ML project cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,91 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Jupyter Notebook checkpoints
+.ipynb_checkpoints/
+
+# VS Code settings
+.vscode/
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Pyre type checker
+.pyre/
+
+# MyPy
+.mypy_cache/
+
+# Pytest
+.pytest_cache/
+
+# Pylint
+.pylint.d/
+
+# Coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+coverage.xml
+*.cover
+.hypothesis/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# IDEs
+.idea/
+*.swp
+*.swo
+
+# macOS
+.DS_Store
+
+# Logs
+*.log
+
+# Datasets, models, and outputs
+*.h5
+*.ckpt
+*.pth
+*.pt
+*.tflite
+*.pb
+*.onnx
+*.joblib
+*.pkl
+*.npy
+*.npz
+models/
+checkpoints/
+logs/
+outputs/
+data/
+datasets/


### PR DESCRIPTION
Added a .gitignore file to exclude unnecessary files like __pycache__, .ipynb_checkpoints/, dataset/model files, logs, and IDE folders. This helps maintain a clean version control structure.