### PR TITLE
Add "Back to top " button in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ This project brings **machine learning** to the front lines of sustainability, h
 
 🧠 Built during the **Shell-Edunet Skills4Future Internship (June–July 2025)**.
 
-[⬆ Back to top](#readme)
+[⬆ Back to top](#️-garbage-classifier-with-transfer-learning)
+
 
 ---
 
@@ -59,7 +60,8 @@ The AI model classifies any uploaded garbage image into:
 | 🟢 Glass     | Jars, shattered pieces       |
 | 🗑️ Trash     | Everything else non-recyclable |
 
-[⬆ Back to top](#readme)
+[⬆ Back to top](#️-garbage-classifier-with-transfer-learning)
+
 ---
 
 ## 🧠 Inside the Model
@@ -72,7 +74,8 @@ The AI model classifies any uploaded garbage image into:
 | 📈 Accuracy          | **98%** on validation                            |
 | 🆚 Baseline          | Compared against **MobileNetV2**                 |
 
-[⬆ Back to top](#readme)
+[⬆ Back to top](#️-garbage-classifier-with-transfer-learning)
+
 ---
 
 ## 📂 Project Layout
@@ -87,7 +90,8 @@ Garbage_Classification/
 ├── model_efficientnet.h5  # Trained weights
 └── README.md
 ```
-[⬆ Back to top](#readme)
+[⬆ Back to top](#️-garbage-classifier-with-transfer-learning)
+
 ---
 
 ## 🚀 Live Demo
@@ -103,7 +107,8 @@ pip install -r requirements.txt
 # Launch the app
 streamlit run app.py
 ```
-[⬆ Back to top](#readme)
+[⬆ Back to top](#️-garbage-classifier-with-transfer-learning)
+
 ---
 
 ## 💡 Features At A Glance
@@ -114,7 +119,8 @@ streamlit run app.py
 📊 Great for learning CNN + Transfer Learning  
 🚮 Encourages environmental awareness
 
-[⬆ Back to top](#readme)
+[⬆ Back to top](#️-garbage-classifier-with-transfer-learning)
+
 ---
 
 ## 🛠 Built With
@@ -126,7 +132,8 @@ streamlit run app.py
 | 🧰 Keras     | Transfer learning pipelines   |
 | 💬 Gradio/Streamlit | Web deployment & UI        |
 
-[⬆ Back to top](#readme)
+[⬆ Back to top](#️-garbage-classifier-with-transfer-learning)
+
 ---
 
 ## 💬 Community & Feedback
@@ -138,7 +145,8 @@ Got feedback? Found a bug? Want to contribute?
 | [GitHub Issues](https://github.com/AditixAnand/Garbage_Classification/issues) | Bug reports, feature requests |
 | [Discussions](https://github.com/AditixAnand/Garbage_Classification/discussions) | Ideas, questions, suggestions |
 
-[⬆ Back to top](#readme)
+[⬆ Back to top](#️-garbage-classifier-with-transfer-learning)
+
 ---
 
 ## 🤝 How to Contribute
@@ -178,7 +186,8 @@ This project was proudly developed as part of the:
   <img src="https://img.shields.io/badge/Sustainability-Focused-green?style=for-the-badge">
 </p>
 
-[⬆ Back to top](#readme)
+[⬆ Back to top](#️-garbage-classifier-with-transfer-learning)
+
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The AI model classifies any uploaded garbage image into:
 | 🟢 Glass     | Jars, shattered pieces       |
 | 🗑️ Trash     | Everything else non-recyclable |
 
+[⬆ Back to top](#readme)
 ---
 
 ## 🧠 Inside the Model
@@ -71,6 +72,7 @@ The AI model classifies any uploaded garbage image into:
 | 📈 Accuracy          | **98%** on validation                            |
 | 🆚 Baseline          | Compared against **MobileNetV2**                 |
 
+[⬆ Back to top](#readme)
 ---
 
 ## 📂 Project Layout
@@ -85,7 +87,7 @@ Garbage_Classification/
 ├── model_efficientnet.h5  # Trained weights
 └── README.md
 ```
-
+[⬆ Back to top](#readme)
 ---
 
 ## 🚀 Live Demo
@@ -101,7 +103,7 @@ pip install -r requirements.txt
 # Launch the app
 streamlit run app.py
 ```
-
+[⬆ Back to top](#readme)
 ---
 
 ## 💡 Features At A Glance
@@ -112,6 +114,7 @@ streamlit run app.py
 📊 Great for learning CNN + Transfer Learning  
 🚮 Encourages environmental awareness
 
+[⬆ Back to top](#readme)
 ---
 
 ## 🛠 Built With
@@ -123,6 +126,7 @@ streamlit run app.py
 | 🧰 Keras     | Transfer learning pipelines   |
 | 💬 Gradio/Streamlit | Web deployment & UI        |
 
+[⬆ Back to top](#readme)
 ---
 
 ## 💬 Community & Feedback
@@ -134,6 +138,7 @@ Got feedback? Found a bug? Want to contribute?
 | [GitHub Issues](https://github.com/AditixAnand/Garbage_Classification/issues) | Bug reports, feature requests |
 | [Discussions](https://github.com/AditixAnand/Garbage_Classification/discussions) | Ideas, questions, suggestions |
 
+[⬆ Back to top](#readme)
 ---
 
 ## 🤝 How to Contribute
@@ -172,6 +177,8 @@ This project was proudly developed as part of the:
 <p align="center">
   <img src="https://img.shields.io/badge/Sustainability-Focused-green?style=for-the-badge">
 </p>
+
+[⬆ Back to top](#readme)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ This project brings **machine learning** to the front lines of sustainability, h
 
 🧠 Built during the **Shell-Edunet Skills4Future Internship (June–July 2025)**.
 
+[⬆ Back to top](#readme)
+
 ---
 
 ## 🔍 What Can It Detect?


### PR DESCRIPTION
Description

A "Back to top" button/link is missing in the README.md, which would improve navigation for readers, especially in longer sections of the document.

Location

The issue exists in the README.md file.

Suggested Fix

Add a "Back to top" button or link at the end of each major section in the README.md so users can quickly return to the table of contents or top of the file.